### PR TITLE
feat: 공통 컴포넌트 버튼 추가

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,23 @@
 import AppRouter from '@/app/router'
+import Button from '@/components/common/Button'
 import './App.css'
 
 export default function App() {
-  return <AppRouter />
+  return (
+    <>
+      <AppRouter />
+      <Button variant="close">닫기</Button>
+      <Button variant="delete">삭제하기</Button>
+      <Button variant="cancel">취소</Button>
+      <Button variant="custom" className="bg-primary-green text-white">
+        복구
+      </Button>
+      <Button variant="custom" className="bg-primary-blue text-white">
+        수정하기
+      </Button>
+      <Button variant="custom" className="bg-primary-yellow text-white">
+        적용하기
+      </Button>
+    </>
+  )
 }

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,3 +1,36 @@
-export function Button() {
-  return <div>Button</div>
+import clsx from 'clsx'
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+type ButtonVariant = 'close' | 'cancel' | 'delete' | 'custom'
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+  children: ReactNode
+  className?: string
+}
+
+const variantStyles: Record<ButtonVariant, string> = {
+  close: `btn btn-filled`,
+  cancel: `btn border-1 border-[#D1D5DB]`,
+  delete: `btn btn-delete`,
+  custom: `btn`,
+}
+
+export default function Button({
+  variant = 'custom',
+  className,
+  children,
+  ...props
+}: ButtonProps) {
+  const baseStyle = `
+    box-border btn py-2 px-4 text-[16px]
+  `
+  const merged = twMerge(clsx(baseStyle, variantStyles[variant], className))
+
+  return (
+    <button className={merged} {...props}>
+      {children}
+    </button>
+  )
 }


### PR DESCRIPTION
## 🔀 PR 제목

공통 컴포넌트 버튼 추가

---

## 🔗 관련 이슈

> #15 

- Close: #15 

---

## ✨ 작업 개요

- 페이지,모달에 쓰일 버튼을 컴포넌트화

---

## 📋 변경 사항

- [ ] Button.tsx  추가
- [ ] ButtonVariant로 닫기, 취소, 삭제, 커스텀으로 나눔
---

## ✅ 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 통과
- [ ] 주요 브라우저(Chrome 기준)에서 기본 동작 확인
- [ ] 신규 로직에 대한 기본 예외 처리(에러/로딩)가 되어 있음
- [ ] UI 변경이 있을 경우, 디자인과 크게 어긋나지 않음

---

## 🧪 테스트 내용 (선택)

> 직접 해본 동작 확인 결과를 적어주세요.

- [ ] 버튼 컴포넌트를 사용할 수 있다.

---
`
<Button variant="close">닫기</Button>
<Button variant="delete">삭제하기</Button>
<Button variant="cancel">취소</Button>
<Button variant="custom" className="bg-primary-green text-white">
  복구
</Button>
`
닫기: close ,
삭제하기: delete,
취소 : cancel
커스텀 : custom (클래스로 자유롭게 변형 가능)
선택하여 사용

## 📸 스크린샷 / 동작 캡처 (선택)

> 레이아웃/스타일 변경이 있으면 첨부해주세요.

- 이미지 또는 동영상 링크:
<img width="342" height="504" alt="image" src="https://github.com/user-attachments/assets/17bf6f9c-ab23-4f7b-a528-d76bb13565c1" />
