### PR TITLE
feat: 공통 모달 컴포넌트 추가

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -11,25 +11,26 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const variantStyles: Record<ButtonVariant, string> = {
-  close: `btn btn-filled`,
-  cancel: `btn border-1 border-[#D1D5DB]`,
-  delete: `btn btn-delete`,
-  custom: `btn`,
+  close: `btn-filled`,
+  cancel: `border-1 border-[#D1D5DB]`,
+  delete: `btn-delete`,
+  custom: ``,
 }
 
 export default function Button({
   variant = 'custom',
   className,
+  type = 'button',
   children,
   ...props
 }: ButtonProps) {
   const baseStyle = `
-    box-border btn py-2 px-4 text-[16px]
+    box-border btn py-2 px-4 text-[16px] cursor-pointer
   `
   const merged = twMerge(clsx(baseStyle, variantStyles[variant], className))
 
   return (
-    <button className={merged} {...props}>
+    <button type={type} className={merged} {...props}>
       {children}
     </button>
   )

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,0 +1,88 @@
+import clsx from 'clsx'
+import { X } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+interface ModalProps {
+  isOpen: boolean
+  onClose: () => void
+  title?: ReactNode
+  children: ReactNode
+  footer?: ReactNode
+  className?: string
+  footerClassName?: string
+  titleClassName?: string
+  contentClassName?: string
+  topCloseButton?: boolean
+}
+
+export default function Modal({
+  isOpen,
+  onClose,
+  title,
+  children,
+  footer,
+  className,
+  titleClassName,
+  contentClassName,
+  footerClassName,
+  topCloseButton,
+}: ModalProps) {
+  if (!isOpen) return null
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="absolute inset-0 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        className={twMerge(
+          clsx(
+            `animate-fadeIn relative z-60 w-full max-w-2xl overflow-hidden rounded-lg bg-white shadow-xl`,
+            className
+          )
+        )}
+      >
+        {title && (
+          <div
+            className={twMerge(
+              clsx(
+                `relative border-b border-[#E5E7EB] p-6 text-lg font-semibold`,
+                titleClassName
+              )
+            )}
+          >
+            {title}
+          </div>
+        )}
+        {topCloseButton && (
+          <button
+            className="absolute top-6.5 right-6 cursor-pointer"
+            aria-label="닫기"
+          >
+            <X onClick={onClose} size={24} />
+          </button>
+        )}
+        <div
+          className={twMerge(
+            clsx(`p-6 text-sm text-[#374151]`, contentClassName)
+          )}
+        >
+          {children}
+        </div>
+        {footer && (
+          <div
+            className={twMerge(
+              clsx(`flex gap-3 border-t border-[#E5E7EB] p-6`, footerClassName)
+            )}
+          >
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 @import '@fontsource/roboto';
 @import '@fontsource/roboto/400.css';
 @import '@fontsource/roboto/500.css';
+@import '@fontsource/roboto/600.css';
 @import '@fontsource/roboto/700.css';
 @import 'tailwindcss';
 


### PR DESCRIPTION
## 🔀 PR 제목

feat: 공통 모달 컴포넌트 추가
---

## 🔗 관련 이슈

- Close: #25

---

## ✨ 작업 개요
상세조회/수정, 컨텐츠 정보 변경하기, 삭제하기 등에 사용되는 모달을 컴포넌트화 시켜 UI 표준화를 진행
---

## 📋 변경 사항

> 주요 변경 내용을 리스트로 정리해주세요.

- [ ] Modal창 구현
- [ ] Button 코드 개선, type 추가

---

## ✅ 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 통과
- [ ] 주요 브라우저(Chrome 기준)에서 기본 동작 확인
- [ ] 신규 로직에 대한 기본 예외 처리(에러/로딩)가 되어 있음
- [ ] UI 변경이 있을 경우, 디자인과 크게 어긋나지 않음

---

## 🧪 테스트 내용 (선택)

> 직접 해본 동작 확인 결과를 적어주세요.

- [ ] Modal 컴포넌트 의도대로 적용 성공

---

### 사용예시

모달창 className,
모달 title, content, footer 모두  className을 통해 스타일 변형 가능하도록(디테일한 디자인 적용)
topCloseButton(x닫기버튼)도 사용여부 결정할 수 있음.
footer에 버튼도 자유롭게 삽입 가능

```
<Modal
        isOpen={open}
        onClose={() => setOpen(false)}
        title="회원 상세 정보"
        topCloseButton
        footerClassName="justify-between bg-[#F9FAFB]"
        footer={
          <>
            <Button variant="custom" className="bg-primary-green text-white">
              권한 변경하기
            </Button>
            <div className="flex justify-end gap-3">
              <Button variant="custom" className="bg-primary-blue text-white">
                수정하기
              </Button>
              <Button variant="delete">삭제하기</Button>
            </div>
          </>
        }
      ></Modal>
```

```
<Modal
        title="회원 삭제 확인"
        className="max-w-md"
        titleClassName="pb-0 border-b-0"
        contentClassName="text-md"
        isOpen={open}
        onClose={() => setOpen(false)}
        footerClassName="justify-end pt-0 border-t-0"
        footer={
          <>
            <Button variant="cancel" onClick={() => setOpen(false)}>
              취소
            </Button>
            <Button variant="delete">삭제</Button>
          </>
        }
      >
        삭제 시 해당 유저와 관련된 모든 데이터가 즉시 삭제되며 되돌릴 수
        없습니다.
      </Modal>
```


## 📸 스크린샷 / 동작 캡처 (선택)
- 이미지 또는 동영상 링크:
<img width="1578" height="730" alt="949A13CE-6511-47CC-9615-9A65495BF69F" src="https://github.com/user-attachments/assets/dcf1c38f-bdbb-411c-85a5-da9d512c5aec" />
<img width="1784" height="1048" alt="FDA7CF17-603E-4A84-A62E-A058E60D3DFD" src="https://github.com/user-attachments/assets/8d037058-e20f-4b7b-b8ef-5845d72788a2" />