### PR TITLE
feat: 공통 input 컴포넌트 추가

### DIFF
--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,0 +1,64 @@
+import clsx from 'clsx'
+import type { InputHTMLAttributes } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+interface inputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label: string
+  editable?: boolean
+  error?: string
+  wrapperClassName?: string
+  labelClassName?: string
+  inputClassName?: string
+}
+export default function Input({
+  label,
+  editable,
+  error,
+  className,
+  wrapperClassName,
+  labelClassName,
+  inputClassName,
+  id,
+  ...props
+}: inputProps) {
+  const mergedInputClass = twMerge(
+    clsx(
+      `bg-[#F9FAFB] text-sm font-regular px-2 w-2xs h-9 rounded-lg transition focus:outline-none focus:ring-2 focus:ring-blue-400`,
+      !editable && ``,
+      error &&
+        `
+        border-red-500 focus:ring-red-400
+      `,
+      className,
+      inputClassName
+    )
+  )
+  return (
+    <div className={twMerge(clsx('flex flex-col gap-2', wrapperClassName))}>
+      {label && (
+        <label
+          htmlFor={id}
+          className={twMerge(
+            clsx('text-sm font-medium text-[#374151]', labelClassName)
+          )}
+        >
+          {label}
+        </label>
+      )}
+      <input
+        id={id}
+        {...props}
+        readOnly={!editable}
+        className={twMerge(
+          clsx(
+            'text-sm font-medium text-[#374151]',
+            mergedInputClass,
+            inputClassName
+          )
+        )}
+        value={props.value ?? ''}
+      />
+      {error && <span className="text-sm text-red-500">{error}</span>}
+    </div>
+  )
+}


### PR DESCRIPTION
## 🔀 PR 제목

feat: 공통 input 컴포넌트 추가


---

## 🔗 관련 이슈

- Close: #27 

---

## ✨ 작업 개요

-상세화면에 정보를 조회/수정할 수 있는 input을 컴포넌트화하여 UI 표준화를 진행
---

## 📋 변경 사항

> 주요 변경 내용을 리스트로 정리해주세요.

- [ ] Input 컴포넌트화(확장성 고려하여 만듦. e.g) 조회,수정일 경우
- [ ] input,label도 따로 클래스를 사용가능

---

## ✅ 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 통과
- [ ] 주요 브라우저(Chrome 기준)에서 기본 동작 확인
- [ ] 신규 로직에 대한 기본 예외 처리(에러/로딩)가 되어 있음
- [ ] UI 변경이 있을 경우, 디자인과 크게 어긋나지 않음

---
### 사용예시

```
<Input label="이메일" value={user.email} editable={false} />
<Input
  type="text"
  label="닉네임"
  value={nickname}
  onChange={(e) => setNickname(e.target.value)}
  inputClassName="w-100"
  editable
/>
```
## 🧪 테스트 내용 (선택)

> 직접 해본 동작 확인 결과를 적어주세요.

- [ ] 해당 컴포넌트를 이용해 페이지의 정보를 조회/수정 가능

---

## 📸 스크린샷 / 동작 캡처 (선택)

- 이미지 또는 동영상 링크:

![0CDEE00E-2B27-42C0-BA1C-0F8B31ABC9E3_4_5005_c](https://github.com/user-attachments/assets/43061bec-e663-4236-ac0b-74e38737b5ca)
