### PR TITLE
feat: 공통 Textarea, ReviewRating 컴포넌트 추가-이중 모달 기능 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "lucide-react": "^0.515.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-rating": "^2.0.5",
         "react-router": "^7.6.2",
         "react-router-dom": "^7.9.6",
         "tailwind-merge": "^3.4.0",
@@ -2607,6 +2608,12 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-FOvQ0YPD5NOfPgMzJihoT+Za5pdkDJWcbpuj1DjaKZIr/gxodQjY/uWEFlTNqW2ugXHUiL8lRQgw63dzKHZdeQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.0.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
@@ -2615,6 +2622,12 @@
       "dependencies": {
         "undici-types": "~7.8.0"
       }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.8",
@@ -2633,6 +2646,12 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
+      "license": "MIT"
     },
     "node_modules/@types/statuses": {
       "version": "2.0.6",
@@ -3903,10 +3922,10 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
     },
     "node_modules/dargs": {
       "version": "8.1.0",
@@ -7250,6 +7269,31 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/react-rating": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-rating/-/react-rating-2.0.5.tgz",
+      "integrity": "sha512-uldxgLCe5bzqGX7V+7/bPgQQj2Kok6eiMgTMxjKOhfhnQkFLDlc4TjMlp7gaJFAHWdbiOnqpiShI7z8as6oWtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "^4.14.105",
+        "@types/react": "^16.0.40"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    },
+    "node_modules/react-rating/node_modules/@types/react": {
+      "version": "16.14.68",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.68.tgz",
+      "integrity": "sha512-GEe60JEJg7wIvnUzXBX/A++ieyum98WXF/q2oFr1RVar8OK8JxU/uEYBXgv7jF87SoaDdxtAq3KUaJFlu02ziw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "^0.16",
+        "csstype": "^3.2.2"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lucide-react": "^0.515.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-rating": "^2.0.5",
     "react-router": "^7.6.2",
     "react-router-dom": "^7.9.6",
     "tailwind-merge": "^3.4.0",

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 import { X } from 'lucide-react'
-import type { ReactNode } from 'react'
+import { useEffect, useRef, type ReactNode } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 interface ModalProps {
@@ -14,6 +14,7 @@ interface ModalProps {
   titleClassName?: string
   contentClassName?: string
   topCloseButton?: boolean
+  zIndex?: number
 }
 
 export default function Modal({
@@ -27,21 +28,53 @@ export default function Modal({
   contentClassName,
   footerClassName,
   topCloseButton,
+  zIndex = 50,
 }: ModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (isOpen) {
+      const prevActiveElement = document.activeElement as HTMLElement
+
+      requestAnimationFrame(() => {
+        modalRef.current?.focus()
+      })
+      return () => {
+        prevActiveElement?.focus()
+      }
+    }
+  }, [isOpen])
+
+  const handlekeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.stopPropagation()
+      onClose()
+    }
+  }
+  const handleContentClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation()
+  }
   if (!isOpen) return null
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      onClick={onClose}
+      style={{ zIndex }}
+    >
       <div
         className="absolute inset-0 flex items-center justify-center bg-black/50 backdrop-blur-sm"
-        onClick={onClose}
         aria-hidden="true"
       />
       <div
         role="dialog"
         aria-modal="true"
+        ref={modalRef}
+        tabIndex={-1}
+        onKeyDown={handlekeyDown}
+        onClick={handleContentClick}
+        style={{ zIndex: zIndex + 1 }}
         className={twMerge(
           clsx(
-            `animate-fadeIn relative z-60 w-full max-w-2xl overflow-hidden rounded-lg bg-white shadow-xl`,
+            `animate-fadeIn relative z-60 w-full max-w-2xl overflow-hidden rounded-lg bg-white shadow-xl focus:outline-none`,
             className
           )
         )}

--- a/src/components/common/ReviewRating.tsx
+++ b/src/components/common/ReviewRating.tsx
@@ -1,0 +1,81 @@
+import clsx from 'clsx'
+import { Star } from 'lucide-react'
+import RatingImport from 'react-rating'
+import { twMerge } from 'tailwind-merge'
+
+type RatingComponentProps = {
+  initialRating?: number
+  fractions?: number
+  emptySymbol?: React.ReactNode
+  fullSymbol?: React.ReactNode
+  className?: string
+  readonly?: boolean
+}
+
+interface ReviewRatingProps {
+  value: number
+  wrapperClassName?: string
+  className?: string
+  size?: number
+  activeColor?: string
+  inactiveColor?: string
+  inactiveFill?: string
+  gap?: number
+  showNumber?: boolean
+  numberClassName?: string
+}
+
+const Rating = RatingImport as unknown as React.FC<RatingComponentProps>
+
+export default function ReviewRating({
+  value,
+  wrapperClassName,
+  className,
+  size = 20,
+  activeColor = '#FACC15',
+  inactiveColor = '#D1D5DB',
+  inactiveFill = '#fff',
+  gap = 4,
+  showNumber = true,
+  numberClassName,
+}: ReviewRatingProps) {
+  return (
+    <div className={twMerge(clsx('flex flex-col gap-2', wrapperClassName))}>
+      <div className={twMerge(clsx(`flex items-center`, className))}>
+        <Rating
+          className="flex items-center leading-1"
+          initialRating={value}
+          readonly
+          fractions={1}
+          emptySymbol={
+            <Star
+              strokeWidth={2}
+              size={size}
+              color={inactiveColor}
+              fill={inactiveFill}
+              style={{ marginRight: gap }}
+            />
+          }
+          fullSymbol={
+            <Star
+              strokeWidth={2}
+              size={size}
+              color={activeColor}
+              fill={activeColor}
+              style={{ marginRight: gap }}
+            />
+          }
+        />
+        {showNumber && (
+          <span
+            className={twMerge(
+              clsx('ml-1 text-sm font-medium text-[#111827]', numberClassName)
+            )}
+          >
+            {Math.floor(value)} / 5
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/common/Textarea.tsx
+++ b/src/components/common/Textarea.tsx
@@ -1,0 +1,69 @@
+import clsx from 'clsx'
+import type { TextareaHTMLAttributes } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  label?: string
+  editable?: boolean
+  error?: string
+  wrapperClassName?: string
+  labelClassName?: string
+  textareaClassName?: string
+}
+
+export default function Textarea({
+  label,
+  editable,
+  error,
+  className,
+  wrapperClassName,
+  labelClassName,
+  textareaClassName,
+  id,
+  ...props
+}: TextareaProps) {
+  const mergedTextareaClass = twMerge(
+    clsx(
+      `
+      bg-[#F9FAFB] text-sm font-regular border-box p-4 rounded-lg overflow-y-auto resize-none
+      transition focus:outline-none focus:ring-2 focus:ring-blue-400
+      text-gray-700
+      `,
+      !editable && ``,
+      error && `border-red-500 focus:ring-red-400`,
+      className,
+      textareaClassName
+    )
+  )
+
+  return (
+    <div className={twMerge(clsx('flex flex-col gap-2', wrapperClassName))}>
+      {label && (
+        <label
+          htmlFor={id}
+          className={twMerge(
+            clsx('text-sm font-medium text-[#374151]', labelClassName)
+          )}
+        >
+          {label}
+        </label>
+      )}
+
+      <textarea
+        id={id}
+        {...props}
+        readOnly={!editable}
+        className={twMerge(
+          clsx(
+            'text-sm font-medium text-[#374151]',
+            mergedTextareaClass,
+            textareaClassName
+          )
+        )}
+        value={props.value ?? ''}
+      />
+
+      {error && <span className="text-sm text-red-500">{error}</span>}
+    </div>
+  )
+}


### PR DESCRIPTION
## 🔀 PR 제목

feat: 공통 Textarea, ReviewRating 컴포넌트 추가-이중 모달 기능 개선
---

## 🔗 관련 이슈

> #31 

- Close: #31 

---

## ✨ 작업 개요

> 어떤 목적의 PR인지 한 줄로 설명해주세요.

-상세조회/수정, 컨텐츠 정보 변경하기, 삭제하기 등에 사용되는 textarea, 스터디 관리 > 리뷰 관리에 사용되는 별점을 컴포넌트화 시켜 UI 표준화를 진행

---

## 📋 변경 사항

> 주요 변경 내용을 리스트로 정리해주세요.

- [x] Textarea, ReviewRating 컴포넌트화
- [x] react-rating 설치
- [x] 다중 모달 기능 구현, Esc키 사용시 닫기로 연결

---

## ✅ 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 통과
- [ ] 주요 브라우저(Chrome 기준)에서 기본 동작 확인
- [ ] 신규 로직에 대한 기본 예외 처리(에러/로딩)가 되어 있음
- [ ] UI 변경이 있을 경우, 디자인과 크게 어긋나지 않음

---

## 🧪 테스트 내용 (선택)

> 직접 해본 동작 확인 결과를 적어주세요.

- [ ] 컴포넌트화 된 UI 사용 가능 확인

---
### 사용예시
```
<Textarea
  label="자기소개"
  value="안녕하세요 홍길동입니다."
  className="h-30 w-100"
  editable={false}
/>
<Textarea
  className="h-30 w-100"
  label="자기소개"
  value={value}
  editable
  onChange={(e) => setValue(e.target.value)}
/>
```
🔼 조회,수정용 가능(Input컴포넌트와 비슷)


` <ReviewRating value={4} gap={6} />`

🔼 단위는 1단위(소수점 X), 별끼리 간격 조정 gap-> margin-right

```
<button onClick={() => setOpen1(true)}>첫 번째 모달 열기</button>
  <Modal
    isOpen={open1}
    onClose={() => setOpen1(false)}
    zIndex={50}
    topCloseButton
  >
    첫번째 모달
    <button onClick={() => setOpen2(true)}>두 번째 모달 열기</button>
  </Modal>
  <Modal
    isOpen={open2}
    onClose={() => setOpen2(false)}
    zIndex={60}
    topCloseButton
  >
    <div>두번째 모달</div>
  </Modal>
```

🔼 
1. [첫 번째 모달] 열림 → 포커스 획득.
2. [두 번째 모달] 열림 → 첫 번째 모달 안의 '열기 버튼'을 prevActiveElement로 기억하고, 자기(두 번째 모달)가 포커스 획득.
3. ESC 클릭 → [두 번째 모달] 닫힘.
4. 이때 return 함수 실행: 포커스를 다시 '첫 번째 모달 안의 버튼'으로 돌려줌.
5. 다시 ESC 클릭 → 현재 포커스가 [첫 번째 모달] 내부에 있으므로, 이벤트가 버블링되어 첫 번째 모달의 onKeyDown이 정상 작동하여 닫힘.

* 모달을 추가할때 나중 z-index값을 높여줘야함

## 📸 스크린샷 / 동작 캡처 (선택)

> 레이아웃/스타일 변경이 있으면 첨부해주세요.

- 이미지 또는 동영상 링크:
<img width="862" height="656" alt="D35A1AE4-FA75-4947-9E6A-FB88C6B64B47" src="https://github.com/user-attachments/assets/72f86aa2-08e7-4463-83ca-a59e25bdd713" />

![157B1FB9-74D1-47BF-A7DB-2695B0B74263_4_5005_c](https://github.com/user-attachments/assets/ddf1e809-8cd1-472d-9f2c-7d845f330602)


<img width="1606" height="422" alt="4C3E30DD-6E05-4003-883C-19B84224D60F" src="https://github.com/user-attachments/assets/86b05fcd-f165-4c72-a674-47242c055289" />
<img width="2036" height="778" alt="EC93D211-AD03-4CC2-82DB-6EBA2A7F9377" src="https://github.com/user-attachments/assets/e111e04c-0ac8-4808-b664-81b93eaf43f6" />
