### PR TITLE
[Style] 메인 레이아웃 콘텐츠 영역 사이즈 조정

### DIFF
--- a/src/pages/layout/index.tsx
+++ b/src/pages/layout/index.tsx
@@ -30,7 +30,7 @@ const Layout = ({ children }: Props) => {
       ) : (
         <>
           <Sidebar />
-          <div className="p-8">
+          <div className="bg-gray-5 flex-1 p-8">
             <h1 className="mb-6 text-2xl font-bold text-gray-900">
               {getPageTitle(pathname)}
             </h1>


### PR DESCRIPTION
## 🔀 PR 제목

[Style] 메인 레이아웃 콘텐츠 영역 사이즈 조정

---

## 🔗 관련 이슈

> 닫을 이슈를 명시해주세요. (자동 close)

- Close: #47 

---

## ✨ 작업 개요

> 어떤 목적의 PR인지 한 줄로 설명해주세요.

- 메인 레이아웃에서 콘텐츠 영역의 사이즈와 여백을 조정하여, 전체 화면 비율과 가독성을 개선했습니다.

---

## 📋 변경 사항

> 주요 변경 내용을 리스트로 정리해주세요.

- [x] `Layout` 컴포넌트에서 메인 콘텐츠 영역 사이즈 조정
  - 사이드바 + 메인 영역 비율 확인 및 메인 영역(`flex-1`) 레이아웃 정리
  - 메인 영역의 패딩(`p-8`) 및 여백 조정으로 콘텐츠 가독성 개선
- [x] 배경 색상/레이아웃 구조 점검
  - 로그인 페이지(`/`)와 어드민 내부 페이지 레이아웃이 일관되게 보이도록 정리
- [x] 페이지 제목 영역(`h1`)과 실제 콘텐츠 사이 간격 재조정

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 브라우저(Chrome 기준)에서 기본 동작 확인
- [x] 신규 로직에 대한 기본 예외 처리(에러/로딩)가 되어 있음
- [x] UI 변경이 있을 경우, 디자인과 크게 어긋나지 않음

---

## 🧪 테스트 내용 (선택)

> 직접 해본 동작 확인 결과를 적어주세요.

- [x] `/members/users`, `/members/withdrawals`, `/study/groups` 등 주요 페이지에서 메인 콘텐츠 영역 너비/여백을 육안으로 확인
- [x] 브라우저 너비를 줄이거나 늘렸을 때 레이아웃이 깨지지 않고 자연스럽게 반응하는지 확인
- [x] 사이드바가 항상 화면 좌측에 고정된 상태에서 메인 콘텐츠 영역이 올바르게 렌더링되는지 확인

---

## 📸 스크린샷 / 동작 캡처 (선택)

> 레이아웃/스타일 변경이 있으면 첨부해주세요.

- 이미지 또는 동영상 링크:
