### PR TITLE
fix: 모달 컴포넌트 body 스크롤 방지 추가

### DIFF
--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -33,12 +33,30 @@ export default function Modal({
   const modalRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     if (isOpen) {
+      const scrollY = window.scrollY
+
+      document.body.style.position = 'fixed'
+      document.body.style.top = `-${scrollY}px`
+      document.body.style.left = '0'
+      document.body.style.right = '0'
+      document.body.style.overflow = 'hidden'
+      document.body.style.width = '100%'
+
       const prevActiveElement = document.activeElement as HTMLElement
 
       requestAnimationFrame(() => {
         modalRef.current?.focus()
       })
       return () => {
+        document.body.style.position = ''
+        document.body.style.top = ''
+        document.body.style.left = ''
+        document.body.style.right = ''
+        document.body.style.overflow = ''
+        document.body.style.width = ''
+
+        window.scrollTo(0, scrollY)
+
         prevActiveElement?.focus()
       }
     }


### PR DESCRIPTION
## 🔀 PR 제목

fix: 모달 컴포넌트 body 스크롤 방지 추가

---

## 🔗 관련 이슈

> #25 

- Close: #25 

---

## ✨ 작업 개요

fix: 모달 작동시 body 부분에 스크롤이 생기는 현상 막기

---

## 📋 변경 사항

> 주요 변경 내용을 리스트로 정리해주세요.

- [ ] body부분에 스타일 처리

---

## ✅ 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 통과
- [ ] 주요 브라우저(Chrome 기준)에서 기본 동작 확인
- [ ] 신규 로직에 대한 기본 예외 처리(에러/로딩)가 되어 있음
- [ ] UI 변경이 있을 경우, 디자인과 크게 어긋나지 않음

---

## 🧪 테스트 내용 (선택)

> 직접 해본 동작 확인 결과를 적어주세요.

- [ ] `/posts` 페이지 진입 시 정상적으로 목록 노출
- [ ] 네트워크 에러 발생 시 에러 메시지 또는 공통 에러 컴포넌트 노출
- [ ] 재로딩 시 캐싱이 의도대로 동작 (React Query)

---

## 📸 스크린샷 / 동작 캡처 (선택)

> 레이아웃/스타일 변경이 있으면 첨부해주세요.

- 이미지 또는 동영상 링크:
