### PR TITLE
feat:권한 변경 분기처리 및 Mock data 추가

### DIFF
--- a/src/mocks/data/accounts.ts
+++ b/src/mocks/data/accounts.ts
@@ -29,7 +29,7 @@ export const mockAccountsList: AccountsList = {
   results: [
     {
       id: 1,
-      email: 'user1@example.com',
+      email: 'admin@example.com',
       nickname: 'hong1',
       name: '홍길동',
       birthday: '1995-01-15',
@@ -255,7 +255,7 @@ export const mockAccountsList: AccountsList = {
 export const mockAccountDetail: AccountsDetail = {
   // mockAccountsList의 첫 번째 유저(id: 1)와 연결
   id: 1,
-  email: 'user1@example.com',
+  email: 'admin@example.com',
   nickname: 'hong1',
   name: '홍길동',
   gender: 'M',
@@ -270,14 +270,14 @@ export const mockAccountDetail: AccountsDetail = {
 export const mockAccountDetailMap: Record<number, AccountsDetail> = {
   1: {
     id: 1,
-    email: 'user1@example.com',
+    email: 'admin@example.com',
     nickname: 'hong1',
     name: '홍길동',
     gender: 'M',
     phone_number: '01000000001',
     birthday: '1995-01-15',
     status: 'active',
-    role: 'user',
+    role: 'admin',
     profile_img_url: 'https://example.com/images/profiles/user1.png',
     created_at: '2025-10-30T10:01:57.505250+09:00',
   },

--- a/src/pages/members/users/UserDetailFooter.tsx
+++ b/src/pages/members/users/UserDetailFooter.tsx
@@ -9,6 +9,7 @@ interface UserDetailFooterProps {
   setIsDeleteModalOpen: React.Dispatch<React.SetStateAction<boolean>>
   handleUserDelete: () => void
   setIsEditMode: React.Dispatch<React.SetStateAction<boolean>>
+  canEditRole: boolean | null
 }
 export function UserDetailFooter({
   setIsRoleModalOpen,
@@ -18,18 +19,21 @@ export function UserDetailFooter({
   setIsDeleteModalOpen,
   handleUserDelete,
   setIsEditMode,
+  canEditRole,
 }: UserDetailFooterProps) {
   return (
     <div className="flex w-full items-center justify-between">
-      <Button
-        variant="custom"
-        className="bg-primary-green text-white"
-        onClick={() => {
-          setIsRoleModalOpen(true)
-        }}
-      >
-        권한 변경하기
-      </Button>
+      {canEditRole && (
+        <Button
+          variant="custom"
+          className="bg-primary-green text-white"
+          onClick={() => {
+            setIsRoleModalOpen(true)
+          }}
+        >
+          권한 변경하기
+        </Button>
+      )}
       <div className="flex justify-end gap-3">
         {isEditMode ? (
           <Button

--- a/src/pages/members/users/UserDetailModal.tsx
+++ b/src/pages/members/users/UserDetailModal.tsx
@@ -14,6 +14,7 @@ import type {
   UserDetailUser,
   UserFormType,
 } from '@/pages/types/users'
+import { useAuthStore } from '@/store/authStore'
 import { formatDataTimeForUserDetail } from '@/utils/formatDataTimeForUserDetail'
 import { formatPhoneNumber } from '@/utils/formatPhoneNumber'
 
@@ -32,6 +33,7 @@ export function UserDetailModal({
     url: SERVICE_URLS.ACCOUNTS.DETAIL(userId || 0),
     enabled: !!userId && isOpen,
   })
+  const { isLoggedIn, user: authUser } = useAuthStore()
   const queryClient = useQueryClient()
   const [isEditMode, setIsEditMode] = useState(false)
   const [isRoleModalOpen, setIsRoleModalOpen] = useState(false)
@@ -168,6 +170,8 @@ export function UserDetailModal({
       profile_img: file ?? undefined,
     })
   }
+  const canEditRole = isLoggedIn && authUser && user?.role === 'admin'
+
   console.log('회원정보 data', user)
 
   if (!isOpen || !userId) return null
@@ -192,6 +196,7 @@ export function UserDetailModal({
           handleUserDelete={handleUserDelete}
           setIsEditMode={setIsEditMode}
           isDeleteModalOpen={isDeleteModalOpen}
+          canEditRole={canEditRole}
         />
       }
     >


### PR DESCRIPTION
## 🔀 PR 제목

feat:권한 변경 분기처리 및 Mock data 추가

---

## 🔗 관련 이슈

> #100 

- Close: #100 
---

## ✨ 작업 개요

> 어떤 목적의 PR인지 한 줄로 설명해주세요.

관리자 권한을 가진 유저는 어드민 페이지 내에서 특정 유저의 권한을 변경할 수 있다.
따라서 권한 변경은
로그인된 관리자&권한이 관리자인 사람이 가능하도록 분기처리 하였다.

지금 테스트 가능한 admin@example.com 권한 Mock Data 추가



---

## 📋 변경 사항

> 주요 변경 내용을 리스트로 정리해주세요.

- [ ] React Query `usePostsQuery` 훅 추가
- [ ] `/posts` API 도메인 함수(`getPosts`) 구현
- [ ] 커뮤니티 목록 페이지에서 더미 데이터 제거, API 데이터로 교체
- [ ] 로딩/에러 상태 UI 추가

---

## ✅ 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 통과
- [ ] 주요 브라우저(Chrome 기준)에서 기본 동작 확인
- [ ] 신규 로직에 대한 기본 예외 처리(에러/로딩)가 되어 있음
- [ ] UI 변경이 있을 경우, 디자인과 크게 어긋나지 않음

---

## 🧪 테스트 내용 (선택)

> 직접 해본 동작 확인 결과를 적어주세요.

- [ ] `/posts` 페이지 진입 시 정상적으로 목록 노출
- [ ] 네트워크 에러 발생 시 에러 메시지 또는 공통 에러 컴포넌트 노출
- [ ] 재로딩 시 캐싱이 의도대로 동작 (React Query)

---

## 📸 스크린샷 / 동작 캡처 (선택)

> 레이아웃/스타일 변경이 있으면 첨부해주세요.

- 이미지 또는 동영상 링크:
