### PR TITLE
feat: 스태프 권한 계정 추가

### DIFF
--- a/src/mocks/data/accounts.ts
+++ b/src/mocks/data/accounts.ts
@@ -55,7 +55,7 @@ export const mockAccountsList: AccountsList = {
       nickname: 'chul3',
       name: '이철수',
       birthday: '1992-07-09',
-      status: 'inactive',
+      status: 'active',
       role: 'staff',
       withdraw_at: '2025-11-04T14:05:20+09:00',
       created_at: '2025-10-30T10:10:20.505250+09:00',

--- a/src/mocks/handlers/handlers.ts
+++ b/src/mocks/handlers/handlers.ts
@@ -30,6 +30,27 @@ const loginHandler = http.post(
       )
     }
 
+    if (body.email === 'user3@example.com' && body.password === 'staff123') {
+      return HttpResponse.json(
+        {
+          access_token: 'token_value_staff',
+          refresh_token: 'dummy_refresh_token_staff',
+          user: {
+            id: 3,
+            email: 'user3@example.com',
+            nickname: 'chul3',
+            name: '이철수',
+            birthday: '1992-07-09',
+            status: 'active',
+            role: 'staff',
+            withdraw_at: '2025-11-04T14:05:20+09:00',
+            created_at: '2025-10-30T10:10:20.505250+09:00',
+          },
+        },
+        { status: 200 }
+      )
+    }
+
     return HttpResponse.json(
       { error_detail: '이메일 또는 비밀번호가 올바르지 않습니다.' },
       { status: 401 }


### PR DESCRIPTION
## 🔀 PR 제목

feat: 스태프 권한 계정 추가

---

## 🔗 관련 이슈

> #108 

- Close: #108 

---

## ✨ 작업 개요

> 어떤 목적의 PR인지 한 줄로 설명해주세요.

feat: 스태프 권한 계정 추가

분기처리 제대로 됐는지 테스트용 계정 추가(임시)
추후 백엔에서 제공해주는 계정으로 대체하여 테스트

---

## 📋 변경 사항

> 주요 변경 내용을 리스트로 정리해주세요.

- [ ] React Query `usePostsQuery` 훅 추가
- [ ] `/posts` API 도메인 함수(`getPosts`) 구현
- [ ] 커뮤니티 목록 페이지에서 더미 데이터 제거, API 데이터로 교체
- [ ] 로딩/에러 상태 UI 추가

---

## ✅ 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 통과
- [ ] 주요 브라우저(Chrome 기준)에서 기본 동작 확인
- [ ] 신규 로직에 대한 기본 예외 처리(에러/로딩)가 되어 있음
- [ ] UI 변경이 있을 경우, 디자인과 크게 어긋나지 않음

---

## 🧪 테스트 내용 (선택)

> 직접 해본 동작 확인 결과를 적어주세요.

- [ ] `/posts` 페이지 진입 시 정상적으로 목록 노출
- [ ] 네트워크 에러 발생 시 에러 메시지 또는 공통 에러 컴포넌트 노출
- [ ] 재로딩 시 캐싱이 의도대로 동작 (React Query)

---

## 📸 스크린샷 / 동작 캡처 (선택)

> 레이아웃/스타일 변경이 있으면 첨부해주세요.

- 이미지 또는 동영상 링크: 
<img width="769" height="473" alt="9A595B95-4B79-4418-9CD1-03FC2E79FB34" src="https://github.com/user-attachments/assets/6e340abd-2fc0-4829-a0ad-cb7d92d870a9" />

