### PR TITLE
[Feat] TagFilterPreview 태그 가시 영역 자동 계산 및 +N 뱃지 표시 로직 추가

### DIFF
--- a/src/features/recruitment/columns/index.tsx
+++ b/src/features/recruitment/columns/index.tsx
@@ -10,13 +10,13 @@ export const RecruitmentColumns = [
   {
     key: 'tags',
     header: '태그',
-    width: '100px',
+    width: '210px',
     render: (row: TagType[]) => {
       const tags = row
 
       return (
         <div className="flex flex-wrap gap-1">
-          <TagFilterPreview tags={tags} koreanLength={16} englishLength={30} />
+          <TagFilterPreview tags={tags} />
         </div>
       )
     },

--- a/src/features/recruitment/ui/RecruitmentFilter/index.tsx
+++ b/src/features/recruitment/ui/RecruitmentFilter/index.tsx
@@ -93,11 +93,7 @@ export default function RecruitmentFilter() {
               'flex cursor-pointer items-center justify-between rounded-lg border border-[#D1D5DB] px-3 py-2'
             )}
           >
-            <TagFilterPreview
-              tags={selectedTagsResult}
-              koreanLength={16}
-              englishLength={30}
-            />
+            <TagFilterPreview tags={selectedTagsResult} />
             <ListFilter className="w-4 text-[#9CA3AF]" />
           </div>
         </div>


### PR DESCRIPTION
## 🔀 PR 제목

[Feat] TagFilterPreview 태그 가시 영역 자동 계산 및 +N 뱃지 표시 로직 추가

---

##  🗒️ 노션 링크

[TagFilterPreview 구현 도전기](https://www.notion.so/TagFilterPreview-2c4e0658abb080358979cb88cdae67fe?source=copy_link).

---

## 🔗 관련 이슈

> 닫을 이슈를 명시해주세요. (자동 close)

- Close: #118 

---

## ✨ 작업 개요

> 어떤 목적의 PR인지 한 줄로 설명해주세요.

TagFilterPreview에서 선택된 태그가 컨테이너 영역을 넘지 않도록 실제 렌더링 기준으로 가시 태그 수를 계산하고, 넘치는 태그는 `+N` 뱃지로 표시하도록 개선했습니다.

---

## 📋 변경 사항

> 주요 변경 내용을 리스트로 정리해주세요.

- `TagFilterPreview` 컴포넌트에 `containerRef` 추가 및 레이아웃 측정 구조 적용
- `useLayoutEffect`를 사용해 부모 컨테이너의 `width`를 조회하고, 각 자식 태그의 `getBoundingClientRect().width`와 `marginRight`를 합산하는 로직 구현
- 부모 너비를 초과하기 전까지의 태그 개수를 `visibleCount`로 계산하여 상태로 관리
- `visibleCount` 기준으로:
  - `tags.slice(0, visibleCount)`만 렌더링
  - 남은 태그 개수는 `+{tags.length - visibleCount}` 형태의 뱃지로 표기
- 태그가 없거나, 계산 결과가 0인 경우에 대한 방어 로직 추가(전체 태그 노출 fallback 등)
- 향후 재사용을 고려해 레이아웃 기반 UI 계산 패턴을 정리한 주석/코멘트 보완

---

## ✅ 체크리스트

- [x] `npm run lint` 통과
- [x] `npm run build` 통과
- [x] 주요 브라우저(Chrome 기준)에서 기본 동작 확인
- [x] 태그 개수/길이에 따라 TagFilterPreview가 의도한 대로 동작함을 수동 테스트로 확인
- [x] 에러/경계 상황(태그 없음, 하나만 선택 등)에 대한 기본 방어 로직 동작 확인

---

## 🧪 테스트 내용 (선택)

> 직접 해본 동작 확인 결과를 적어주세요.

- [x] 태그 1~3개 선택 시, 모든 태그가 정상적으로 노출되고 `+N` 뱃지는 보이지 않는다.
- [x] 태그를 다수 선택하여 부모 컨테이너 너비를 초과하는 경우, 일부만 노출되고 나머지는 `+N` 뱃지로 표시된다.
- [x] 브라우저 크기를 줄이거나 늘려도 태그 개수가 자연스럽게 다시 계산된다.
- [x] 기존 필터 로직(선택/해제, 초기화 등)과의 충돌이 없다.

---

## 📸 스크린샷 / 동작 캡처 (선택)

> 레이아웃/스타일 변경이 있으면 첨부해주세요.

- 이미지 또는 동영상 링크:

### 구현 전 (특정 케이스는 적용이 되지 않는다.)
https://github.com/user-attachments/assets/7ce23556-6bbf-4ab6-96a3-37fb0a9abcfb

### 구현 (완벽 그 자체)
https://github.com/user-attachments/assets/88760191-fc21-4426-949a-247753bd6780


