### PR TITLE
feat: 회원 복구 확인 모달창 추가

### DIFF
--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -80,7 +80,7 @@ export default function Modal({
           {/* Top Close Button */}
           {topCloseButton && (
             <Dialog.Close
-              className="absolute top-6.5 right-6 cursor-pointer"
+              className="absolute top-6.5 right-6 cursor-pointer outline-none focus:outline-none"
               aria-label="닫기"
             >
               <X size={24} />

--- a/src/pages/members/withdrawals/WithdrawalDetailFooter.tsx
+++ b/src/pages/members/withdrawals/WithdrawalDetailFooter.tsx
@@ -1,6 +1,8 @@
 import { useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
 
 import Button from '@/components/common/Button'
+import Modal from '@/components/common/Modal'
 import { SERVICE_URLS } from '@/config/serviceUrls'
 import { useMutateQuery } from '@/hooks/useMutateQuery'
 interface WithdrawalDetailFooterProps {
@@ -9,12 +11,11 @@ interface WithdrawalDetailFooterProps {
   withdrawalId: number
 }
 export function WithdrawalDetailFooter({
-  //status,
   withdrawalId,
   onClose,
 }: WithdrawalDetailFooterProps) {
   const queryClient = useQueryClient()
-
+  const [isRecoveryModalOpen, setIsRecoveryModalOpen] = useState(false)
   const RestoreUserMutation = useMutateQuery<string, number>({
     url: SERVICE_URLS.ACCOUNTS.ACTIVATE(withdrawalId!),
     method: 'post',
@@ -24,8 +25,10 @@ export function WithdrawalDetailFooter({
       queryClient.invalidateQueries({ queryKey: ['users-list'], exact: false })
     },
   })
-
   const handleUserRecovery = () => {
+    setIsRecoveryModalOpen(true)
+  }
+  const handleUserRecoveryDone = () => {
     RestoreUserMutation.mutate(withdrawalId)
   }
   return (
@@ -46,6 +49,41 @@ export function WithdrawalDetailFooter({
         >
           회원 복구하기
         </Button>
+        <Modal
+          isOpen={isRecoveryModalOpen}
+          onClose={onClose}
+          title="회원 탈퇴 상세 정보"
+          className="z-50 w-md"
+          titleClassName="border-b-0"
+          contentClassName="overflow-y-auto pt-0 h-20"
+          footerClassName="p-0 border-t-0 pb-6 pr-6"
+          footer={
+            <div className="flex w-full justify-end">
+              <Button
+                variant="cancel"
+                type="button"
+                onClick={() => {
+                  setIsRecoveryModalOpen(false)
+                }}
+              >
+                취소
+              </Button>
+              <Button
+                variant="custom"
+                type="button"
+                className="btn bg-primary-green ml-3 text-white"
+                onClick={handleUserRecoveryDone}
+              >
+                복구
+              </Button>
+            </div>
+          }
+        >
+          <p>
+            해당 유저의 탈퇴요청은 삭제되며 해당 유저는 즉시 이용가능
+            <span className="block">한 상태로 복구됩니다.</span>
+          </p>
+        </Modal>
       </div>
     </div>
   )


### PR DESCRIPTION
## 🔀 PR 제목

feat: 회원 복구 확인 모달창 추가

---

## 🔗 관련 이슈

> #142 

- Close: #142 

---

## ✨ 작업 개요

> 어떤 목적의 PR인지 한 줄로 설명해주세요.

회원 복구 확인 모달창 추가
복구 버튼 클릭시 복구 잘됨
(복구 Mockdata 연결)

---

## 📋 변경 사항

> 주요 변경 내용을 리스트로 정리해주세요.

- [ ] React Query `usePostsQuery` 훅 추가
- [ ] `/posts` API 도메인 함수(`getPosts`) 구현
- [ ] 커뮤니티 목록 페이지에서 더미 데이터 제거, API 데이터로 교체
- [ ] 로딩/에러 상태 UI 추가

---

## ✅ 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 통과
- [ ] 주요 브라우저(Chrome 기준)에서 기본 동작 확인
- [ ] 신규 로직에 대한 기본 예외 처리(에러/로딩)가 되어 있음
- [ ] UI 변경이 있을 경우, 디자인과 크게 어긋나지 않음

---

## 🧪 테스트 내용 (선택)

> 직접 해본 동작 확인 결과를 적어주세요.

- [ ] `/posts` 페이지 진입 시 정상적으로 목록 노출
- [ ] 네트워크 에러 발생 시 에러 메시지 또는 공통 에러 컴포넌트 노출
- [ ] 재로딩 시 캐싱이 의도대로 동작 (React Query)

---

## 📸 스크린샷 / 동작 캡처 (선택)

> 레이아웃/스타일 변경이 있으면 첨부해주세요.

- 이미지 또는 동영상 링크:
