### PR TITLE
[feat] admin최초 진입시 대시보드 active상태로 수정

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -13,7 +13,7 @@ import {
   UserRoundX,
   Users,
 } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Link, useLocation } from 'react-router'
 
 import { ROUTE_PATHS } from '@/app/router/routePaths'
@@ -21,21 +21,40 @@ import { useLogout } from '@/hooks'
 
 const TITLE_BASE_STYLE =
   'flex w-full cursor-pointer items-center justify-between rounded-lg px-2 py-3'
+
 const LINK_BASE_STYLE =
-  'flex w-[200px] items-center rounded-lg px-2 py-3 hover:bg-[#FEF9C3] hover:text-[#854D0E] active:font-semibold active:bg-[#FDE38A] group aria-[current=true]:bg-[#FEF9C3] aria-[current=true]:text-[#854D0E]'
+  'flex w-[200px] items-center rounded-lg px-2 py-3 hover:bg-[#FEF9C3] hover:text-[#854D0E] active:font-semibold active:bg-[#FDE38A] group aria-[current=page]:bg-[#FEF9C3] aria-[current=page]:text-[#854D0E]'
+
 const ICON_STYLE =
-  'group-hover:stroke-[#854D0E] group-active:scale-[1.2] aria-[current=true]:stroke-[#854D0E]'
+  'group-hover:stroke-[#854D0E] group-active:scale-[1.2] aria-[current=page]:stroke-[#854D0E]'
 
 export default function Sidebar() {
-  const [userToggle, setUserToggle] = useState(false)
-  const [studyToggle, setStudyToggle] = useState(false)
-  const [recruitmentToggle, setRecruitmentToggle] = useState(false)
+  type OpenMenu = 'users' | 'study' | 'recruitment' | null
+  const [openMenu, setOpenMenu] = useState<OpenMenu>(null)
 
   const location = useLocation()
   const pathname = location.pathname
+  const isUserOpen = openMenu === 'users'
+  const isStudyOpen = openMenu === 'study'
+  const isRecruitmentOpen = openMenu === 'recruitment'
 
   const logout = useLogout()
-
+  const toggleMenu = (menu: OpenMenu) => {
+    setOpenMenu((prev) => (prev === menu ? null : menu))
+  }
+  useEffect(() => {
+    if (pathname.startsWith(ROUTE_PATHS.MEMBERS.DASHBOARD)) {
+      setOpenMenu('users')
+    } else if (pathname.startsWith(ROUTE_PATHS.MEMBERS.USERS)) {
+      setOpenMenu('users')
+    } else if (pathname.startsWith(ROUTE_PATHS.MEMBERS.WITHDRAWALS)) {
+      setOpenMenu('users')
+    } else if (pathname.startsWith('/study')) {
+      setOpenMenu('study')
+    } else if (pathname.startsWith('/recruitment')) {
+      setOpenMenu('recruitment')
+    }
+  }, [pathname])
   return (
     <div className="flex h-dvh w-[256px] flex-col items-center justify-between border-r border-[#E5E7EB]">
       <div className="flex flex-col items-center">
@@ -44,15 +63,12 @@ export default function Sidebar() {
         </div>
 
         <div className="flex w-[223px] flex-col">
-          <div
-            className={TITLE_BASE_STYLE}
-            onClick={() => setUserToggle(!userToggle)}
-          >
+          <div className={TITLE_BASE_STYLE} onClick={() => toggleMenu('users')}>
             <div className="flex items-center">
               <UserRoundCog color="#374151" size={20} />
               <div className="ml-3">회원관리</div>
             </div>
-            {userToggle ? (
+            {isUserOpen ? (
               <ChevronRight size={16} color="#374151" />
             ) : (
               <ChevronDown size={16} color="#374151" />
@@ -60,45 +76,65 @@ export default function Sidebar() {
           </div>
 
           <div
-            className={`grid transition-all duration-200 ease-out ${userToggle ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'} `}
+            className={`grid transition-all duration-200 ease-out ${isUserOpen ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'} `}
           >
             <div className="flex flex-col items-end overflow-hidden">
               <Link
                 to={ROUTE_PATHS.MEMBERS.USERS}
                 className={LINK_BASE_STYLE}
-                aria-current={pathname === ROUTE_PATHS.MEMBERS.USERS}
+                aria-current={
+                  pathname === ROUTE_PATHS.MEMBERS.USERS ? 'page' : undefined
+                }
               >
                 <User
                   size={16}
                   color="#4B5563"
                   className={ICON_STYLE}
-                  aria-current={pathname === ROUTE_PATHS.MEMBERS.USERS}
+                  aria-current={
+                    pathname === ROUTE_PATHS.MEMBERS.USERS ? 'page' : undefined
+                  }
                 />
                 <div className="ml-3">유저 관리</div>
               </Link>
               <Link
                 to={ROUTE_PATHS.MEMBERS.WITHDRAWALS}
                 className={LINK_BASE_STYLE}
-                aria-current={pathname === ROUTE_PATHS.MEMBERS.WITHDRAWALS}
+                aria-current={
+                  pathname === ROUTE_PATHS.MEMBERS.WITHDRAWALS
+                    ? 'page'
+                    : undefined
+                }
               >
                 <UserRoundX
                   size={16}
                   color="#4B5563"
                   className={ICON_STYLE}
-                  aria-current={pathname === ROUTE_PATHS.MEMBERS.WITHDRAWALS}
+                  aria-current={
+                    pathname === ROUTE_PATHS.MEMBERS.WITHDRAWALS
+                      ? 'page'
+                      : undefined
+                  }
                 />
                 <div className="ml-3">탈퇴 관리</div>
               </Link>
               <Link
                 to={ROUTE_PATHS.MEMBERS.DASHBOARD}
                 className={LINK_BASE_STYLE}
-                aria-current={pathname === ROUTE_PATHS.MEMBERS.DASHBOARD}
+                aria-current={
+                  pathname === ROUTE_PATHS.MEMBERS.DASHBOARD
+                    ? 'page'
+                    : undefined
+                }
               >
                 <LayoutDashboard
                   size={16}
                   color="#4B5563"
                   className={ICON_STYLE}
-                  aria-current={pathname === ROUTE_PATHS.MEMBERS.DASHBOARD}
+                  aria-current={
+                    pathname === ROUTE_PATHS.MEMBERS.DASHBOARD
+                      ? 'page'
+                      : undefined
+                  }
                 />
                 <div className="ml-3">대시보드</div>
               </Link>
@@ -107,15 +143,12 @@ export default function Sidebar() {
         </div>
 
         <div className="flex w-[223px] flex-col">
-          <div
-            className={TITLE_BASE_STYLE}
-            onClick={() => setStudyToggle(!studyToggle)}
-          >
+          <div className={TITLE_BASE_STYLE} onClick={() => toggleMenu('study')}>
             <div className="flex items-center">
               <BookOpen color="#374151" size={20} />
               <div className="ml-3">스터디 관리</div>
             </div>
-            {studyToggle ? (
+            {isStudyOpen ? (
               <ChevronRight size={16} color="#374151" />
             ) : (
               <ChevronDown size={16} color="#374151" />
@@ -123,45 +156,57 @@ export default function Sidebar() {
           </div>
 
           <div
-            className={`grid transition-all duration-200 ease-out ${studyToggle ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'} `}
+            className={`grid transition-all duration-200 ease-out ${isStudyOpen ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'} `}
           >
             <div className="flex flex-col items-end overflow-hidden">
               <Link
                 to={ROUTE_PATHS.STUDY.COURSES}
                 className={LINK_BASE_STYLE}
-                aria-current={pathname === ROUTE_PATHS.STUDY.COURSES}
+                aria-current={
+                  pathname === ROUTE_PATHS.STUDY.COURSES ? 'page' : undefined
+                }
               >
                 <GraduationCap
                   size={16}
                   color="#4B5563"
                   className={ICON_STYLE}
-                  aria-current={pathname === ROUTE_PATHS.STUDY.COURSES}
+                  aria-current={
+                    pathname === ROUTE_PATHS.STUDY.COURSES ? 'page' : undefined
+                  }
                 />
                 <div className="ml-3">강의 관리</div>
               </Link>
               <Link
                 to={ROUTE_PATHS.STUDY.GROUPS}
                 className={LINK_BASE_STYLE}
-                aria-current={pathname === ROUTE_PATHS.STUDY.GROUPS}
+                aria-current={
+                  pathname === ROUTE_PATHS.STUDY.GROUPS ? 'page' : undefined
+                }
               >
                 <Users
                   size={16}
                   color="#4B5563"
                   className={ICON_STYLE}
-                  aria-current={pathname === ROUTE_PATHS.STUDY.GROUPS}
+                  aria-current={
+                    pathname === ROUTE_PATHS.STUDY.GROUPS ? 'page' : undefined
+                  }
                 />
                 <div className="ml-3">스터디 그룹 관리</div>
               </Link>
               <Link
                 to={ROUTE_PATHS.STUDY.REVIEWS}
                 className={LINK_BASE_STYLE}
-                aria-current={pathname === ROUTE_PATHS.STUDY.REVIEWS}
+                aria-current={
+                  pathname === ROUTE_PATHS.STUDY.REVIEWS ? 'page' : undefined
+                }
               >
                 <Star
                   size={16}
                   color="#4B5563"
                   className={ICON_STYLE}
-                  aria-current={pathname === ROUTE_PATHS.STUDY.REVIEWS}
+                  aria-current={
+                    pathname === ROUTE_PATHS.STUDY.REVIEWS ? 'page' : undefined
+                  }
                 />
                 <div className="ml-3">리뷰 관리</div>
               </Link>
@@ -172,13 +217,13 @@ export default function Sidebar() {
         <div className="flex w-[223px] flex-col">
           <div
             className={TITLE_BASE_STYLE}
-            onClick={() => setRecruitmentToggle(!recruitmentToggle)}
+            onClick={() => toggleMenu('recruitment')}
           >
             <div className="flex items-center">
               <Megaphone color="#374151" size={20} />
               <div className="ml-3">스터디 구인 공고 관리</div>
             </div>
-            {recruitmentToggle ? (
+            {isRecruitmentOpen ? (
               <ChevronRight size={16} color="#374151" />
             ) : (
               <ChevronDown size={16} color="#374151" />
@@ -186,28 +231,36 @@ export default function Sidebar() {
           </div>
 
           <div
-            className={`grid transition-all duration-200 ease-out ${recruitmentToggle ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'} `}
+            className={`grid transition-all duration-200 ease-out ${isRecruitmentOpen ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'} `}
           >
             <div className="flex flex-col items-end overflow-hidden">
               <Link
                 to={ROUTE_PATHS.RECRUITMENT.LIST}
-                onClick={() => setRecruitmentToggle(true)}
                 className={LINK_BASE_STYLE}
-                aria-current={pathname === ROUTE_PATHS.RECRUITMENT.LIST}
+                aria-current={
+                  pathname === ROUTE_PATHS.RECRUITMENT.LIST ? 'page' : undefined
+                }
               >
                 <ReceiptText
                   size={16}
                   color="#4B5563"
                   className={ICON_STYLE}
-                  aria-current={pathname === ROUTE_PATHS.RECRUITMENT.LIST}
+                  aria-current={
+                    pathname === ROUTE_PATHS.RECRUITMENT.LIST
+                      ? 'page'
+                      : undefined
+                  }
                 />
                 <div className="ml-3">공고 관리</div>
               </Link>
               <Link
                 to={ROUTE_PATHS.RECRUITMENT.APPLICATIONS}
-                onClick={() => setRecruitmentToggle(true)}
                 className={LINK_BASE_STYLE}
-                aria-current={pathname === ROUTE_PATHS.RECRUITMENT.APPLICATIONS}
+                aria-current={
+                  pathname === ROUTE_PATHS.RECRUITMENT.APPLICATIONS
+                    ? 'page'
+                    : undefined
+                }
               >
                 <UserRoundPlus
                   size={16}
@@ -215,6 +268,8 @@ export default function Sidebar() {
                   className={ICON_STYLE}
                   aria-current={
                     pathname === ROUTE_PATHS.RECRUITMENT.APPLICATIONS
+                      ? 'page'
+                      : undefined
                   }
                 />
                 <div className="ml-3">지원 내역 관리</div>

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -22,7 +22,8 @@ export default function Login() {
   const location = useLocation()
   const queryClient = useQueryClient()
   const from =
-    (location.state as LocationState)?.from || `${ROUTE_PATHS.MEMBERS.USERS}`
+    (location.state as LocationState)?.from ||
+    `${ROUTE_PATHS.MEMBERS.DASHBOARD}`
   const clearAuthHard = useAuthStore((s) => s.clearAuthHard)
   const { role } = useAuthRole()
   const [didLogin, setDidLogin] = useState(false)


### PR DESCRIPTION
## 🔀 PR 제목

[feat] admin최초 진입시 대시보드 active상태로 수정

---

## 🔗 관련 이슈

> 닫을 이슈를 명시해주세요. (자동 close)

- Close: #152 

---

## ✨ 작업 개요

> 어떤 목적의 PR인지 한 줄로 설명해주세요.
- 디자인에 나와있는데로 로그인 후 최초 진입시 대시보드- 회원가입 추세 메뉴가 나오도록 수정

---

## 📋 변경 사항

> 주요 변경 내용을 리스트로 정리해주세요.

- [ ] sidebar.tsx, index.tsx  로그인 후 보이는 페이지 변경 유저목록  -> 대시보드로

---

## ✅ 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 통과
- [ ] 주요 브라우저(Chrome 기준)에서 기본 동작 확인
- [ ] 신규 로직에 대한 기본 예외 처리(에러/로딩)가 되어 있음
- [ ] UI 변경이 있을 경우, 디자인과 크게 어긋나지 않음

---

## 🧪 테스트 내용 (선택)

> 직접 해본 동작 확인 결과를 적어주세요.

- [ ] `/posts` 페이지 진입 시 정상적으로 목록 노출
- [ ] 네트워크 에러 발생 시 에러 메시지 또는 공통 에러 컴포넌트 노출
- [ ] 재로딩 시 캐싱이 의도대로 동작 (React Query)

---

## 📸 스크린샷 / 동작 캡처 (선택)

> 레이아웃/스타일 변경이 있으면 첨부해주세요.

- 이미지 또는 동영상 링크:
- 
<img width="2560" height="1463" alt="image" src="https://github.com/user-attachments/assets/89ec1e6b-7114-42d6-aa3d-d4ac92cb9a99" />

