### PR TITLE
[Refactor] 관리자 패널 레이아웃/로그인 UI 정리 및 README 보강

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,14 +125,12 @@ src/
 - **clsx / tailwind-merge**: 조건부 className 구성 및 Tailwind 클래스 충돌 정리
 
 ### 품질/협업 도구
-
 - **ESLint**: 코드 품질/규칙 검사
 - **Prettier (+ prettier-plugin-tailwindcss)**: 코드 포맷팅 및 Tailwind 클래스 정렬
 - **Husky + lint-staged**: 커밋 전 자동 lint/format 수행
 - **Commitlint**: 커밋 메시지 컨벤션 강제
 
 ### 테스트/목데이터
-
 - **MSW**: Mock API(개발 단계에서 목데이터/실API 전환 지원)
 - **Vitest + Testing Library + JSDOM**: 단위/컴포넌트 테스트 환경
 
@@ -150,7 +148,6 @@ src/
   - `staff`는 조회만 가능(수정/삭제 불가)
 
 ### 공통 UI/데이터 처리
-
 - 테이블: 정렬/페이지네이션/검색/필터
 - 모달: 상세보기/셀렉트박스 등
 
@@ -164,12 +161,10 @@ src/
 - Package manager: `npm`
 
 ### 브랜치 전략
-
 - `main`: 배포용
 - `develop`: 개발 통합
 
 작업 브랜치 네이밍:
-
 ```bash
 feat/{issue-number}-{short-kebab}
 fix/{issue-number}-{short-kebab}
@@ -178,7 +173,6 @@ refactor/{issue-number}-{short-kebab}
 ```
 
 ### 커밋 메시지 규칙
-
 - `{type}: {subject}`
 - subject: 한국어, 명령문 스타일, 대문자 시작 금지, 마침표 금지
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -58,7 +58,7 @@ export default function Sidebar() {
   return (
     <div className="flex h-dvh w-[256px] flex-col items-center justify-between border-r border-[#E5E7EB]">
       <div className="flex flex-col items-center">
-        <div className="text-bold flex h-7 w-[256px] cursor-default items-center p-6 text-xl font-bold">
+        <div className="text-bold flex w-[256px] cursor-default items-center p-6 text-xl font-bold">
           관리자 패널
         </div>
 

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -66,49 +66,48 @@ export default function Login() {
   }, [didLogin, role, navigate, from, clearAuthHard, queryClient])
 
   return (
-    <div className="flex items-center justify-between">
-      <div className="flex h-full w-6/10 items-center justify-center">
-        <div className="flex flex-col items-center">
-          <img src="/logo.png" alt="logo" />
-          <div className="cursor-default py-4 text-3xl font-bold text-[#111827]">
-            관리자 로그인
-          </div>
-          <div className="cursor-default py-6">
-            <span className="text-[#F6A818]">admin 계정</span>을 통해 로그인을
-            진행해주세요.
-          </div>
-
-          <form onSubmit={handleSubmit} className="flex flex-col">
-            <input
-              name="email"
-              type="email"
-              required
-              placeholder="아이디 (example@gmail.com)"
-              className={INPUT_STYLE}
-            />
-            <input
-              name="password"
-              type="password"
-              required
-              placeholder="비밀번호 (6~15자의 영문 대소문자, 숫자, 특수문자 포함"
-              className={INPUT_STYLE}
-            />
-            {error && (
-              <p className="mb-3 text-sm text-red-500">
-                {error.message && '아이디/비밀번호를 확인해주세요.'}
-              </p>
-            )}
-            <Button
-              type="submit"
-              disabled={isPending}
-              className="h-[52px] w-[328px] bg-[#F6A818] text-white hover:bg-amber-400 hover:font-bold"
-            >
-              {isPending ? '로그인 중...' : '로그인'}
-            </Button>
-          </form>
+    <div className="relative flex items-center justify-center">
+      <div className="flex h-full w-11/20 items-center justify-center" />
+      <div className="h-dvh w-9/20 bg-[#F6A818] opacity-10" />
+      <div className="absolute flex flex-col items-center">
+        <img src="/logo.png" alt="logo" />
+        <div className="cursor-default py-4 text-3xl font-bold text-[#111827]">
+          관리자 로그인
         </div>
+        <div className="cursor-default py-6">
+          <span className="text-[#F6A818]">admin 계정</span>을 통해 로그인을
+          진행해주세요.
+        </div>
+
+        <form onSubmit={handleSubmit} className="flex flex-col">
+          <input
+            name="email"
+            type="email"
+            required
+            placeholder="아이디 (example@gmail.com)"
+            className={INPUT_STYLE}
+          />
+          <input
+            name="password"
+            type="password"
+            required
+            placeholder="비밀번호 (6~15자의 영문 대소문자, 숫자, 특수문자 포함"
+            className={INPUT_STYLE}
+          />
+          {error && (
+            <p className="mb-3 text-sm text-red-500">
+              {error.message && '아이디/비밀번호를 확인해주세요.'}
+            </p>
+          )}
+          <Button
+            type="submit"
+            disabled={isPending}
+            className="h-[52px] w-[328px] bg-[#F6A818] text-white hover:bg-amber-400 hover:font-bold"
+          >
+            {isPending ? '로그인 중...' : '로그인'}
+          </Button>
+        </form>
       </div>
-      <div className="h-dvh w-4/10 bg-[#F6A818] opacity-10" />
     </div>
   )
 }


### PR DESCRIPTION
## 🔀 PR 제목

[Refactor] 관리자 패널 레이아웃/로그인 UI 정리 및 README 보강

---

## 🔗 관련 이슈

> 닫을 이슈를 명시해주세요. (자동 close)

- Close: #188 

---

## ✨ 작업 개요

> 어떤 목적의 PR인지 한 줄로 설명해주세요.

관리자 패널 Sidebar 레이아웃과 로그인 화면 UI를 정리하고, 프로젝트 온보딩을 위해 README 내용을 보강한다.

---

## 📋 변경 사항

> 주요 변경 내용을 리스트로 정리해주세요.

* Sidebar: 관리자 패널 영역 불필요 높이 제거
* Login: 입력 폼 중앙 정렬 및 스타일 수정
* Docs: README에 주요 기능/폴더 구조/협업 규칙 추가

---

## ✅ 체크리스트

* npm run lint 통과
* npm run build 통과
* 주요 화면(관리자 패널/로그인) 레이아웃 깨짐 없음
* README 내용이 최신 상태로 반영됨

---

## 🧪 테스트 내용 (선택)

> 직접 해본 동작 확인 결과를 적어주세요.

* 로그인 페이지 진입 시 입력 폼이 중앙 정렬되는지 확인
* 관리자 패널 Sidebar 영역 스크롤/레이아웃 정상 동작 확인