### PR TITLE
fix: 프로필 이미지 업로드 버그 수정

### DIFF
--- a/src/pages/members/users/UserDetailModal.tsx
+++ b/src/pages/members/users/UserDetailModal.tsx
@@ -49,6 +49,7 @@ export function UserDetailModal({
       gender: user.gender,
       birthday: user.birthday,
       role: ROLE_LABEL[user.role as keyof typeof ROLE_LABEL] ?? '',
+      profile_img_url: user.profile_img_url,
       joinDateTime: dayjs(user.created_at)
         .locale('ko')
         .format('YYYY. M. D. A h:mm:ss'),
@@ -60,7 +61,7 @@ export function UserDetailModal({
       return
     }
 
-    setProfileImg(`${user.profile_img_url}?t=${Date.now()}`)
+    setProfileImg(user.profile_img_url)
   }, [user?.profile_img_url])
   const updateUserMutation = useMutateQuery({
     url: SERVICE_URLS.ACCOUNTS.DETAIL(userId!),
@@ -91,7 +92,6 @@ export function UserDetailModal({
   useEffect(() => {
     if (!isOpen) {
       setIsEditMode(false)
-      setProfileImg('')
     }
     if (!isRoleModalOpen) {
       setRole('')
@@ -154,7 +154,7 @@ export function UserDetailModal({
       nickname: form.nickname,
       phone_number: form.phone,
       status: form.status,
-      profile_img_url: profileImg || undefined,
+      profile_img_url: form.profile_img_url,
     })
 
     if (!parsed.success) {

--- a/src/pages/members/users/UserDetailProfile.tsx
+++ b/src/pages/members/users/UserDetailProfile.tsx
@@ -15,27 +15,29 @@ export function UserDetailProfile({
   errors,
 }: UserDetailProfile) {
   const inputId = `profile-input-${user.id}`
+  const DEFAULT_PROFILE = 'https://placehold.co/80'
+
   return (
     <>
       <div className="flex items-center justify-start gap-4">
-        <div className="relative px-2 pb-6 text-center">
+        <div className="relative px-2 text-center">
           <label
             htmlFor={inputId}
-            className={`flex flex-col items-center gap-1 ${
+            className={`flex flex-col items-center gap-1 pb-6 ${
               isEditMode ? 'cursor-pointer' : 'cursor-default'
             }`}
           >
             <img
-              src={profileImg || user.profile_img_url}
+              src={profileImg || user.profile_img_url || DEFAULT_PROFILE}
               alt="회원 프로필 사진"
               className="h-20 w-20 rounded-full object-cover"
               onError={(e) => {
-                e.currentTarget.src = 'https://placehold.co/80'
+                e.currentTarget.src = DEFAULT_PROFILE
               }}
             />
 
             {isEditMode && (
-              <span className="text-base font-medium text-[#2563EB]">
+              <span className="absolute -bottom-2 left-0 text-base font-medium whitespace-nowrap text-[#2563EB]">
                 프로필 사진 변경
               </span>
             )}
@@ -57,7 +59,11 @@ export function UserDetailProfile({
           <span className="text-base">{user.email}</span>
         </div>
       </div>
-
+      {isEditMode && !profileImg && !user.profile_img_url && (
+        <span className="text-xs text-gray-400">
+          프로필 사진을 등록해 주세요
+        </span>
+      )}
       {isEditMode && errors.profile_img && (
         <span className="text-sm text-red-500">{errors.profile_img}</span>
       )}

--- a/src/pages/members/users/hook/useUserDetailForm.ts
+++ b/src/pages/members/users/hook/useUserDetailForm.ts
@@ -17,6 +17,7 @@ export function useUserDetailForm(user?: UserDetailUser, userId?: number) {
     birthday: '',
     role: '',
     joinDateTime: '',
+    profile_img_url: '',
   })
   const [errors, setErrors] = useState<Record<string, string>>({})
   useEffect(() => {
@@ -32,6 +33,7 @@ export function useUserDetailForm(user?: UserDetailUser, userId?: number) {
       gender: user.gender,
       birthday: user.birthday,
       role: ROLE_LABEL[user.role as keyof typeof ROLE_LABEL],
+      profile_img_url: user.profile_img_url,
       joinDateTime: dayjs(user.created_at)
         .locale('ko')
         .format('YYYY. M. D. A h:mm:ss'),

--- a/src/pages/types/users.ts
+++ b/src/pages/types/users.ts
@@ -47,6 +47,7 @@ export interface UserFormType {
   birthday: string
   role: string
   joinDateTime: string
+  profile_img_url: string
 }
 
 export interface UserDetailFormProps {


### PR DESCRIPTION
## 🔀 PR 제목

fix: 프로필 이미지 업로드 버그 수정

---

## 🔗 관련 이슈

> 닫을 이슈를 명시해주세요. (자동 close)

- Close: #152 

---

## ✨ 작업 개요

> 어떤 목적의 PR인지 한 줄로 설명해주세요.

프로필 이미지 업로드 버그 수정
변경된 이미지 반영 개선

---

## 📋 변경 사항

> 주요 변경 내용을 리스트로 정리해주세요.

- [ ] React Query `usePostsQuery` 훅 추가
- [ ] `/posts` API 도메인 함수(`getPosts`) 구현
- [ ] 커뮤니티 목록 페이지에서 더미 데이터 제거, API 데이터로 교체
- [ ] 로딩/에러 상태 UI 추가

---

## ✅ 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 통과
- [ ] 주요 브라우저(Chrome 기준)에서 기본 동작 확인
- [ ] 신규 로직에 대한 기본 예외 처리(에러/로딩)가 되어 있음
- [ ] UI 변경이 있을 경우, 디자인과 크게 어긋나지 않음

---

## 🧪 테스트 내용 (선택)

> 직접 해본 동작 확인 결과를 적어주세요.

- [ ] `/posts` 페이지 진입 시 정상적으로 목록 노출
- [ ] 네트워크 에러 발생 시 에러 메시지 또는 공통 에러 컴포넌트 노출
- [ ] 재로딩 시 캐싱이 의도대로 동작 (React Query)

---

## 📸 스크린샷 / 동작 캡처 (선택)

> 레이아웃/스타일 변경이 있으면 첨부해주세요.

- 이미지 또는 동영상 링크:
