### PR TITLE
fix: 전화번호, 프로필 업로드 수정

### DIFF
--- a/src/pages/members/users/UserDetailLeft.tsx
+++ b/src/pages/members/users/UserDetailLeft.tsx
@@ -47,8 +47,11 @@ export function UserDetailLeft({
     const onlyNumbers = e.target.value.replace(/\D/g, '')
 
     setForm((prev) => ({ ...prev, phone: onlyNumbers }))
-  }
 
+    if (onlyNumbers.length === 11) {
+      validateField('phone_number', onlyNumbers)
+    }
+  }
   const handleFormChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
     if (name === 'phone') {
@@ -67,14 +70,9 @@ export function UserDetailLeft({
   }
 
   const handlePhoneBlur = () => {
-    const raw = form.phone.replace(/\D/g, '')
-    validateField('phone_number', raw)
-    setForm((prev) => ({
-      ...prev,
-      phone: raw, // form 내부 값은 raw 숫자 유지!
-    }))
+    if (form.phone === '') return
+    validateField('phone_number', form.phone)
   }
-
   return (
     <div className="flex flex-col gap-6">
       <Input label="회원ID" name="id" value={form.id} />
@@ -139,6 +137,7 @@ export function UserDetailLeft({
         editable={isEditMode}
         onChange={handlePhoneChange}
         onBlur={handlePhoneBlur}
+        maxLength={13}
       />
       {errors.phone_number && (
         <span className="text-sm text-red-500">{errors.phone_number}</span>

--- a/src/pages/members/users/UserDetailModal.tsx
+++ b/src/pages/members/users/UserDetailModal.tsx
@@ -35,7 +35,14 @@ export function UserDetailModal({
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const [profileImg, setProfileImg] = useState<string>('')
   const [role, setRole] = useState('')
+  const toAbsoluteUrl = (path?: string | null) => {
+    if (!path) return undefined
+    if (path.startsWith('http')) return path
 
+    const base = import.meta.env.VITE_API_BASE_URL.replace(/\/$/, '')
+    const cleanPath = path.replace(/^\//, '')
+    return `${base}/${cleanPath}`
+  }
   useEffect(() => {
     if (!user) return
 
@@ -49,7 +56,7 @@ export function UserDetailModal({
       gender: user.gender,
       birthday: user.birthday,
       role: ROLE_LABEL[user.role as keyof typeof ROLE_LABEL] ?? '',
-      profile_img_url: user.profile_img_url,
+      profile_img_url: toAbsoluteUrl(user.profile_img_url),
       joinDateTime: dayjs(user.created_at)
         .locale('ko')
         .format('YYYY. M. D. A h:mm:ss'),
@@ -61,7 +68,7 @@ export function UserDetailModal({
       return
     }
 
-    setProfileImg(user.profile_img_url)
+    setProfileImg(toAbsoluteUrl(user.profile_img_url) ?? '')
   }, [user?.profile_img_url])
   const updateUserMutation = useMutateQuery({
     url: SERVICE_URLS.ACCOUNTS.DETAIL(userId!),
@@ -164,7 +171,6 @@ export function UserDetailModal({
 
     updateUserMutation.mutate(parsed.data)
   }
-
   const { isAdmin } = useAuthRole()
   if (isLoading) return <Loading label="회원 정보를 로딩 중입니다..." />
   if (!isOpen) return null

--- a/src/pages/members/users/hook/useUserDetailForm.ts
+++ b/src/pages/members/users/hook/useUserDetailForm.ts
@@ -17,7 +17,7 @@ export function useUserDetailForm(user?: UserDetailUser, userId?: number) {
     birthday: '',
     role: '',
     joinDateTime: '',
-    profile_img_url: '',
+    profile_img_url: undefined,
   })
   const [errors, setErrors] = useState<Record<string, string>>({})
   useEffect(() => {
@@ -33,7 +33,7 @@ export function useUserDetailForm(user?: UserDetailUser, userId?: number) {
       gender: user.gender,
       birthday: user.birthday,
       role: ROLE_LABEL[user.role as keyof typeof ROLE_LABEL],
-      profile_img_url: user.profile_img_url,
+      profile_img_url: user.profile_img_url ?? undefined,
       joinDateTime: dayjs(user.created_at)
         .locale('ko')
         .format('YYYY. M. D. A h:mm:ss'),
@@ -43,12 +43,53 @@ export function useUserDetailForm(user?: UserDetailUser, userId?: number) {
     field: T,
     value: unknown
   ) => {
-    const result = userUpdateSchema.shape[field]?.safeParse(value)
+    // 공통: 빈 값이면 에러 제거
+    if (typeof value === 'string' && value.trim() === '') {
+      setErrors((prev) => {
+        const next = { ...prev }
+        delete next[field]
+        return next
+      })
+      return
+    }
 
-    setErrors((prev) => ({
-      ...prev,
-      [field]: result?.success ? '' : result?.error.issues[0].message,
-    }))
+    // 전화번호 전용 검증
+    if (field === 'phone_number') {
+      const v = String(value)
+
+      if (v.length !== 11) {
+        setErrors((prev) => ({
+          ...prev,
+          phone_number: '전화번호는 숫자 11자리여야 합니다.',
+        }))
+      } else {
+        setErrors((prev) => {
+          const next = { ...prev }
+          delete next.phone_number
+          return next
+        })
+      }
+      return
+    }
+
+    // 그 외 필드는 Zod로
+    const schema = userUpdateSchema.shape[field]
+    if (!schema) return
+
+    const result = schema.safeParse(value)
+
+    if (!result.success) {
+      setErrors((prev) => ({
+        ...prev,
+        [field]: result.error.issues[0].message,
+      }))
+    } else {
+      setErrors((prev) => {
+        const next = { ...prev }
+        delete next[field]
+        return next
+      })
+    }
   }
 
   return {

--- a/src/pages/members/users/schema/userUpdateSchema.ts
+++ b/src/pages/members/users/schema/userUpdateSchema.ts
@@ -19,20 +19,12 @@ export const userUpdateSchema = z.object({
   phone_number: z
     .string()
     .regex(/^\d{11}$/, '전화번호는 숫자 11자리여야 합니다.'),
-
   status: z.enum(['active', 'inactive', 'withdraw']),
 
-  profile_img_url: z
-    .string()
-    .refine((v) => {
-      try {
-        new URL(v)
-        return true
-      } catch {
-        return false
-      }
-    }, '유효한 이미지 URL이 아닙니다.')
-    .optional(),
+  profile_img_url: z.preprocess(
+    (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+    z.string().url('유효한 이미지 URL이 아닙니다.').optional()
+  ),
 })
 
 export type UserUpdateSchema = z.infer<typeof userUpdateSchema>

--- a/src/pages/types/users.ts
+++ b/src/pages/types/users.ts
@@ -31,7 +31,7 @@ export interface UserDetailUser {
   name: string
   nickname: string
   phone_number: string
-  profile_img_url: string
+  profile_img_url: string | null
   role: string
   status: string
 }
@@ -47,7 +47,7 @@ export interface UserFormType {
   birthday: string
   role: string
   joinDateTime: string
-  profile_img_url: string
+  profile_img_url?: string
 }
 
 export interface UserDetailFormProps {


### PR DESCRIPTION
## 🔀 PR 제목

> 예시: [Feat] 게시글 목록 페이지 API 연동  
> 예시: [Bug] 로그인 후 새로고침 시 사용자 정보 초기화 문제 수정

---

## 🔗 관련 이슈

> 닫을 이슈를 명시해주세요. (자동 close)

- Close: #152 

---

## ✨ 작업 개요

> 어떤 목적의 PR인지 한 줄로 설명해주세요.
전화번호, 프로필 업로드 수정

연락처 삭제 후 다시 입력받으면
전화번호 11자리 invalid input 에러가 떴었음.
프로필 url도 상대경로로 변경하여 적용

---

## 📋 변경 사항

> 주요 변경 내용을 리스트로 정리해주세요.

- [ ] React Query `usePostsQuery` 훅 추가
- [ ] `/posts` API 도메인 함수(`getPosts`) 구현
- [ ] 커뮤니티 목록 페이지에서 더미 데이터 제거, API 데이터로 교체
- [ ] 로딩/에러 상태 UI 추가

---

## ✅ 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 통과
- [ ] 주요 브라우저(Chrome 기준)에서 기본 동작 확인
- [ ] 신규 로직에 대한 기본 예외 처리(에러/로딩)가 되어 있음
- [ ] UI 변경이 있을 경우, 디자인과 크게 어긋나지 않음

---

## 🧪 테스트 내용 (선택)

> 직접 해본 동작 확인 결과를 적어주세요.

- [ ] `/posts` 페이지 진입 시 정상적으로 목록 노출
- [ ] 네트워크 에러 발생 시 에러 메시지 또는 공통 에러 컴포넌트 노출
- [ ] 재로딩 시 캐싱이 의도대로 동작 (React Query)

---

## 📸 스크린샷 / 동작 캡처 (선택)

> 레이아웃/스타일 변경이 있으면 첨부해주세요.

- 이미지 또는 동영상 링크:
