### PR TITLE
[Refactor] refreshAccessToken 요청 정리 및 MSW 활성화 코드 정돈

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -27,15 +27,7 @@ async function refreshAccessToken(): Promise<string> {
     throw new AxiosError('토큰이 없어 refresh 불가')
   }
 
-  const res = await refreshClient.post<{ access_token: string }>(
-    SERVICE_URLS.ACCOUNTS.REFRESH,
-    undefined,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    }
-  )
+  const res = await refreshClient.post(SERVICE_URLS.ACCOUNTS.REFRESH)
   return res.data.access_token
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,16 +1,17 @@
 import { createRoot } from 'react-dom/client'
 
 import App from '@/app/App'
+import { worker } from '@/mocks/browser'
 import './index.css'
 
-// async function enableMocking() {
-//   if (!import.meta.env.DEV) return
+async function enableMocking() {
+  if (!import.meta.env.DEV) return
 
-//   if (import.meta.env.VITE_USE_MOCK !== 'true') return
+  if (import.meta.env.VITE_USE_MOCK !== 'true') return
 
-//   return worker.start({ onUnhandledRequest: 'bypass' })
-// }
+  return worker.start({ onUnhandledRequest: 'bypass' })
+}
 
-// enableMocking().then(() => {
-createRoot(document.getElementById('root')!).render(<App />)
-// })
+enableMocking().then(() => {
+  createRoot(document.getElementById('root')!).render(<App />)
+})


### PR DESCRIPTION
…king 활성화 코드 정리

## 🔀 PR 제목

[Refactor] refreshAccessToken 요청 정리 및 MSW 활성화 코드 정돈


---

## 🔗 관련 이슈

> 닫을 이슈를 명시해주세요. (자동 close)

- Close: #208 

---

## ✨ 작업 개요

> 어떤 목적의 PR인지 한 줄로 설명해주세요.

refreshAccessToken 요청부와 MSW 활성화 로직을 정리해 인증/개발환경 동작을 명확히 했습니다.

---

## 📋 변경 사항

> 주요 변경 내용을 리스트로 정리해주세요.

* axios.ts의 refreshAccessToken에서 불필요한 요청 헤더 처리 제거 및 호출부 단순화
* main.tsx의 MSW 활성화 조건(DEV + VITE_USE_MOCK) 중심으로 코드 정리
* .env.development / .env.production 환경에서 MSW on/off 동작 확인

---

## ✅ 체크리스트

* npm run lint 통과
* npm run build 통과
* 개발 환경에서 MSW on/off 의도대로 동작 확인
* refresh 갱신 후 재요청 흐름(401 → refresh → retry) 정상 동작 확인

---

## 🧪 테스트 내용 (선택)

> 직접 해본 동작 확인 결과를 적어주세요.

* .env.development에서 VITE_USE_MOCK=true → MSW 활성화 확인
* .env.development에서 VITE_USE_MOCK=false → MSW 비활성화 확인
* refresh 토큰 갱신 시 정상적으로 access token 갱신되는지 확인