### PR TITLE
fix: 탈퇴상세 hook 분리

### DIFF
--- a/src/pages/members/withdrawals/hook/useWithdrawalsRecovery.ts
+++ b/src/pages/members/withdrawals/hook/useWithdrawalsRecovery.ts
@@ -1,0 +1,26 @@
+import { useQueryClient } from '@tanstack/react-query'
+
+import { handleApiError } from '@/api/handleApiError'
+import { SERVICE_URLS } from '@/config'
+import { useMutateQuery } from '@/hooks/useMutateQuery'
+import { USER_API_ERROR_MESSAGE } from '@/pages/members/users/api/userErrorMessageMap'
+
+export function useWithdrawalsRecovery(userId: number) {
+  const queryClient = useQueryClient()
+
+  return useMutateQuery<void, void>({
+    url: SERVICE_URLS.ACCOUNTS.ACTIVATE(userId),
+    method: 'patch',
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['Withdraw-list'],
+        exact: false,
+      })
+      queryClient.invalidateQueries({
+        queryKey: ['users-list'],
+        exact: false,
+      })
+    },
+    onError: (error) => handleApiError(error, USER_API_ERROR_MESSAGE.recovery),
+  })
+}


### PR DESCRIPTION
## 🔀 PR 제목

fix: 탈퇴상세 hook 분리

---

## 🔗 관련 이슈

> 닫을 이슈를 명시해주세요. (자동 close)

- Close: #152 

---

## ✨ 작업 개요

> 어떤 목적의 PR인지 한 줄로 설명해주세요.

 탈퇴상세 복구 patch hook 분리 

---

## 📋 변경 사항

> 주요 변경 내용을 리스트로 정리해주세요.

- [ ] React Query `usePostsQuery` 훅 추가
- [ ] `/posts` API 도메인 함수(`getPosts`) 구현
- [ ] 커뮤니티 목록 페이지에서 더미 데이터 제거, API 데이터로 교체
- [ ] 로딩/에러 상태 UI 추가

---

## ✅ 체크리스트

- [ ] `npm run lint` 통과
- [ ] `npm run build` 통과
- [ ] 주요 브라우저(Chrome 기준)에서 기본 동작 확인
- [ ] 신규 로직에 대한 기본 예외 처리(에러/로딩)가 되어 있음
- [ ] UI 변경이 있을 경우, 디자인과 크게 어긋나지 않음

---

## 🧪 테스트 내용 (선택)

> 직접 해본 동작 확인 결과를 적어주세요.

- [ ] `/posts` 페이지 진입 시 정상적으로 목록 노출
- [ ] 네트워크 에러 발생 시 에러 메시지 또는 공통 에러 컴포넌트 노출
- [ ] 재로딩 시 캐싱이 의도대로 동작 (React Query)

---

## 📸 스크린샷 / 동작 캡처 (선택)

> 레이아웃/스타일 변경이 있으면 첨부해주세요.

- 이미지 또는 동영상 링크:
